### PR TITLE
add MessageRaw and IPOther subchannels

### DIFF
--- a/src/main/java/com/velocitypowered/bungeequack/BungeeQuack.java
+++ b/src/main/java/com/velocitypowered/bungeequack/BungeeQuack.java
@@ -15,6 +15,7 @@ import com.velocitypowered.api.proxy.messages.*;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.util.UuidUtils;
 import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.text.serializer.plain.PlainComponentSerializer;
 import org.slf4j.Logger;
 
 import java.util.*;
@@ -90,6 +91,14 @@ public class BungeeQuack {
             out.writeUTF(connection.getPlayer().getRemoteAddress().getHostString());
             out.writeInt(connection.getPlayer().getRemoteAddress().getPort());
         }
+        if (subChannel.equals("IPOther")) {
+            server.getPlayer(in.readUTF()).ifPresent(player -> {
+                out.writeUTF("IPOther");
+                out.writeUTF(player.getUsername());
+                out.writeUTF(player.getRemoteAddress().getHostString());
+                out.writeUTF(player.getRemoteAddress().getPort());
+            });
+        }
         if (subChannel.equals("PlayerCount")) {
             String target = in.readUTF();
             if (target.equals("ALL")) {
@@ -134,6 +143,19 @@ public class BungeeQuack {
             } else {
                 server.getPlayer(target).ifPresent(player -> {
                     player.sendMessage(LegacyComponentSerializer.INSTANCE.deserialize(message));
+                });
+            }
+        }
+        if (subChannel.equals("MessageRaw")) {
+            String target = in.readUTF();
+            String rawMessage = in.readUTF();
+            if (target.equals("ALL")) {
+                for (Player player : server.getAllPlayers()) {
+                    player.sendMessage(PlainComponentSerializer.INSTANCE.deserialize(rawMessage));
+                }
+            } else {
+                server.getPlayer(target).ifPresent(player -> {
+                    player.sendMessage(PlainComponentSerializer.INSTANCE.deserialize(rawMessage));
                 });
             }
         }


### PR DESCRIPTION
BungeeCord has two new plugin message subchannels: `MessageRaw` and `IPOther`. MessageRaw was implemented on the first of July in [this commit](https://github.com/SpigotMC/BungeeCord/commit/a64c34d29e74afa97500bd41d4a836af5ed30ddf#diff-7d693c73818c5cfbbf156ae567ad8e8e) and IPOther was implemented four days ago [here](https://github.com/SpigotMC/BungeeCord/commit/023f407b0d5c91aac271a4aa87525d0bf2648743#diff-7d693c73818c5cfbbf156ae567ad8e8e). Both were undocumented on the [SpigotMC Bukkit & Bungee Plugin Message wiki](https://www.spigotmc.org/wiki/bukkit-bungee-plugin-messaging-channel/#wikiContent) until today.

I did not actually test either subchannel on Velocity because I couldn't get gradle to output a BungeeQuack jar with a valid velocity-plugin.json insde. (I normally use Maven)